### PR TITLE
added limitation for depth for nestedset/NodeMoveAction

### DIFF
--- a/src/messages/ru/jstw.php
+++ b/src/messages/ru/jstw.php
@@ -2,6 +2,7 @@
 return [
     'Can not move node as root!' => 'Нельзя сделать дочерний элемент корневым!',
     'Invalid node id or parent id received!' => 'Получены неврные id родительского или перемещаемого элемента!',
+    'Can not move node because max depth ({depthLimit}) is exceeded!' => 'Нельзя переместить элемент потому что превышена максимальная вложенность ({depthLimit})!',
     'Invalid data provided!' => 'Получены неверные данные!',
     "Old parent with id '{id}' not found!" => "Старый родительский элемент с id '{id}' не найден!",
     'New previous sibling does not exist' => 'Невозможно определить нового предыдущего соседа!',


### PR DESCRIPTION
Hi,
I have added limitation for moving nodes by depth, also I have improved code for extending by replacing "private" to "protected" properties and methods in actions/nestedset/NodeMoveAction.php